### PR TITLE
Support metadata patching without needing to add adapter code

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -84,7 +84,7 @@ handwritten adapters use:
   `nunchaku-fp16` where the underlying model and kernels support it.
 - [ ] Add manifest hooks for Flux-style cache integrations, including
   TeaCache, first-block cache, and double-block cache behavior.
-- [ ] Bind model-family runtime APIs, such as LoRA loading and adapter
+- [x] Bind model-family runtime APIs, such as LoRA loading and adapter
   management, when a manifest target corresponds to an existing family adapter.
 
 ## Notes

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -62,6 +62,27 @@ current porting backlog for `nunchaku_lite`:
 - [ ] Async/offload paths for lower-VRAM inference where supported by the
   original implementation.
 
+## Runtime Manifest Adapter Backlog
+
+The generic `manifest` adapter currently covers checkpoint-driven linear
+replacement and simple structural rewrites. The remaining work is to let
+manifest-declared checkpoints opt into the same model-level fast paths that the
+handwritten adapters use:
+
+- [ ] Declare fused attention groups so separate `to_q`, `to_k`, and `to_v`
+  projections can be replaced by a model-specific attention wrapper.
+- [ ] Route manifest-created attention wrappers through
+  `fused_qkv_norm_rotary` when the model exposes compatible Q/K norms and
+  rotary embeddings.
+- [ ] Express two-layer MLP patterns that can use `fused_gelu_mlp` instead of
+  running the projections and activation as separate modules.
+- [ ] Expose manifest-driven attention backend selection, including
+  `nunchaku-fp16` where the underlying model and kernels support it.
+- [ ] Add manifest hooks for Flux-style cache integrations, including
+  TeaCache, first-block cache, and double-block cache behavior.
+- [ ] Bind model-family runtime APIs, such as LoRA loading and adapter
+  management, when a manifest target corresponds to an existing family adapter.
+
 ## Notes
 
 - `nunchaku_lite` does not import or require the full `nunchaku` Python package.

--- a/src/nunchaku_lite/adapters/manifest.py
+++ b/src/nunchaku_lite/adapters/manifest.py
@@ -1,0 +1,281 @@
+"""Generic runtime-manifest adapter for Nunchaku Lite checkpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from ..core import PatchOptions, register_adapter
+from ..linear import AWQW4A16Linear, SVDQW4A4Linear
+from ..manifest import RuntimeManifest, RuntimeManifestTarget, parse_runtime_manifest
+from .common import SVDQPatchContext, finalize_svdq_checkpoint, prepare_transformer_dtype
+
+
+class ManifestAdapter:
+    """Generic adapter driven by ``quantization_config.runtime_manifest``."""
+
+    target = "manifest"
+
+    def matches(self, transformer: torch.nn.Module) -> bool:
+        """The manifest adapter is selected from checkpoint metadata, not model type."""
+
+        del transformer
+        return False
+
+    def patch(
+        self,
+        transformer: torch.nn.Module,
+        checkpoint_state: dict[str, torch.Tensor],
+        quantization_config: dict[str, Any],
+        options: PatchOptions,
+    ) -> dict[str, torch.Tensor]:
+        """Patch declared manifest targets and return the checkpoint state."""
+
+        manifest = parse_runtime_manifest(quantization_config)
+        if manifest is None:
+            raise ValueError("target='manifest' requires quantization_config.runtime_manifest metadata.")
+
+        context = _manifest_context(transformer, manifest, options)
+        prepare_transformer_dtype(transformer, context)
+        _apply_structural_patches(transformer, manifest)
+        for target in manifest.targets:
+            _replace_target(transformer, target, context)
+
+        finalize_svdq_checkpoint(transformer, checkpoint_state, context)
+        transformer._nunchaku_lite_manifest_patched = True
+        return checkpoint_state
+
+
+class SplitLinearInput(nn.Module):
+    """Linear replacement that splits input features across child linears."""
+
+    def __init__(self, linears: list[nn.Linear], in_features_list: list[int]) -> None:
+        super().__init__()
+        self.linears = nn.ModuleList(linears)
+        self.in_features_list = list(in_features_list)
+        self.in_features = sum(self.in_features_list)
+        self.out_features = self.linears[0].out_features
+
+    @classmethod
+    def from_linear(cls, linear: nn.Linear, splits: list[int]) -> "SplitLinearInput":
+        splits = _complete_splits(linear.in_features, splits, "split_linear_input")
+        linears = []
+        start = 0
+        for index, split in enumerate(splits):
+            child = nn.Linear(
+                split,
+                linear.out_features,
+                bias=linear.bias is not None and index == len(splits) - 1,
+                device=linear.weight.device,
+                dtype=linear.weight.dtype,
+            )
+            if not linear.weight.is_meta:
+                child.weight.data.copy_(linear.weight[:, start : start + split])
+                if child.bias is not None and linear.bias is not None:
+                    child.bias.data.copy_(linear.bias)
+            linears.append(child)
+            start += split
+        return cls(linears, splits)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        chunks = x.split(self.in_features_list, dim=-1)
+        return sum(linear(chunk.contiguous()) for linear, chunk in zip(self.linears, chunks, strict=True))
+
+
+class SplitLinearOutput(nn.Module):
+    """Linear replacement that splits output features across child linears."""
+
+    def __init__(self, linears: list[nn.Linear], out_features_list: list[int]) -> None:
+        super().__init__()
+        self.linears = nn.ModuleList(linears)
+        self.out_features_list = list(out_features_list)
+        self.in_features = self.linears[0].in_features
+        self.out_features = sum(self.out_features_list)
+
+    @classmethod
+    def from_linear(cls, linear: nn.Linear, splits: list[int]) -> "SplitLinearOutput":
+        splits = _complete_splits(linear.out_features, splits, "split_linear_output")
+        linears = []
+        start = 0
+        for split in splits:
+            child = nn.Linear(
+                linear.in_features,
+                split,
+                bias=linear.bias is not None,
+                device=linear.weight.device,
+                dtype=linear.weight.dtype,
+            )
+            if not linear.weight.is_meta:
+                child.weight.data.copy_(linear.weight[start : start + split])
+                if child.bias is not None and linear.bias is not None:
+                    child.bias.data.copy_(linear.bias[start : start + split])
+            linears.append(child)
+            start += split
+        return cls(linears, splits)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.cat([linear(x) for linear in self.linears], dim=-1)
+
+
+def _manifest_context(transformer: nn.Module, manifest: RuntimeManifest, options: PatchOptions) -> SVDQPatchContext:
+    parameter = next(transformer.parameters(), None)
+    torch_dtype = options.torch_dtype or (parameter.dtype if parameter is not None else torch.bfloat16)
+    return SVDQPatchContext(
+        precision=manifest.runtime_precision or options.precision,
+        rank=manifest.rank,
+        torch_dtype=torch_dtype,
+        requested_torch_dtype=options.torch_dtype,
+    )
+
+
+def _apply_structural_patches(transformer: nn.Module, manifest: RuntimeManifest) -> None:
+    for patch in manifest.structural_patches:
+        patch_type = patch["type"]
+        for module_name in _matched_module_names(transformer, patch["module"]):
+            module = transformer.get_submodule(module_name)
+            if isinstance(module, (SplitLinearInput, SplitLinearOutput)):
+                continue
+            if not isinstance(module, nn.Linear):
+                raise TypeError(
+                    f"{patch_type} expected nn.Linear at {module_name!r}, got {module.__class__.__name__}."
+                )
+            splits = _resolve_splits(module, patch["args"].get("splits", []), input_split=patch_type == "split_linear_input")
+            if patch_type == "split_linear_input":
+                replacement = SplitLinearInput.from_linear(module, splits)
+            elif patch_type == "split_linear_output":
+                replacement = SplitLinearOutput.from_linear(module, splits)
+            else:
+                raise ValueError(f"Unsupported runtime_manifest structural patch type {patch_type!r}.")
+            _set_submodule(transformer, module_name, replacement)
+
+
+def _replace_target(transformer: nn.Module, target: RuntimeManifestTarget, context: SVDQPatchContext) -> None:
+    for source_module in target.source_modules:
+        try:
+            transformer.get_submodule(source_module)
+        except AttributeError as exc:
+            raise ValueError(
+                f"runtime_manifest target {target.checkpoint_prefix!r} source module {source_module!r} "
+                "does not exist after structural patches."
+            ) from exc
+
+    try:
+        module = transformer.get_submodule(target.checkpoint_prefix)
+    except AttributeError as exc:
+        raise ValueError(
+            "runtime_manifest target checkpoint_prefix "
+            f"{target.checkpoint_prefix!r} does not exist after structural patches."
+        ) from exc
+
+    in_features = getattr(module, "in_features", None)
+    out_features = getattr(module, "out_features", None)
+    if not isinstance(in_features, int) or not isinstance(out_features, int):
+        raise TypeError(
+            f"runtime_manifest target {target.checkpoint_prefix!r} must expose integer in_features/out_features."
+        )
+
+    if target.nunchaku_op == "svdq_w4a4":
+        _validate_svdq_group_size(target)
+        replacement = SVDQW4A4Linear(
+            in_features=in_features,
+            out_features=out_features,
+            rank=target.rank,
+            bias=target.has_bias,
+            precision=target.runtime_precision,
+            torch_dtype=context.torch_dtype,
+            device=_module_device(module),
+        )
+    elif target.nunchaku_op in {"awq_w4a16", "adanorm_awq_w4a16"}:
+        if target.precision != "int4":
+            raise ValueError(f"{target.nunchaku_op} target {target.checkpoint_prefix!r} requires precision='int4'.")
+        replacement = AWQW4A16Linear(
+            in_features=in_features,
+            out_features=out_features,
+            bias=target.has_bias,
+            group_size=target.group_size,
+            torch_dtype=context.torch_dtype,
+            device=_module_device(module),
+        )
+    else:
+        raise ValueError(f"Unsupported runtime_manifest nunchaku_op {target.nunchaku_op!r}.")
+
+    _set_submodule(transformer, target.checkpoint_prefix, replacement)
+
+
+def _validate_svdq_group_size(target: RuntimeManifestTarget) -> None:
+    expected = 16 if target.precision == "fp4" else 64
+    if target.group_size != expected:
+        raise ValueError(
+            f"svdq_w4a4 target {target.checkpoint_prefix!r} precision={target.precision!r} "
+            f"requires group_size={expected}, got {target.group_size}."
+        )
+
+
+def _resolve_splits(linear: nn.Linear, splits: list[Any], *, input_split: bool) -> list[int]:
+    resolved = []
+    for split in splits:
+        if split == "out_features":
+            resolved.append(linear.out_features)
+        elif split == "in_features":
+            resolved.append(linear.in_features)
+        elif isinstance(split, int):
+            resolved.append(split)
+        else:
+            raise ValueError(f"Unsupported runtime_manifest split value {split!r}.")
+    total = linear.in_features if input_split else linear.out_features
+    return _complete_splits(total, resolved, "split_linear_input" if input_split else "split_linear_output")
+
+
+def _complete_splits(total: int, splits: list[int], patch_type: str) -> list[int]:
+    remaining = total - sum(splits)
+    if remaining > 0:
+        splits = [*splits, remaining]
+    splits = [split for split in splits if split > 0]
+    if len(splits) < 2:
+        raise ValueError(f"{patch_type} requires at least two positive splits.")
+    if sum(splits) != total:
+        raise ValueError(f"{patch_type} splits must sum to the module feature dimension.")
+    return splits
+
+
+def _matched_module_names(transformer: nn.Module, pattern: str) -> list[str]:
+    modules = dict(transformer.named_modules())
+    matches = [name for name in modules if name and _path_matches(pattern, name)]
+    if not matches:
+        raise ValueError(f"runtime_manifest structural patch pattern {pattern!r} matched no modules.")
+    return matches
+
+
+def _path_matches(pattern: str, path: str) -> bool:
+    pattern_parts = pattern.split(".")
+    path_parts = path.split(".")
+    if len(pattern_parts) != len(path_parts):
+        return False
+    return all(
+        pattern_part == "*" or pattern_part == path_part
+        for pattern_part, path_part in zip(pattern_parts, path_parts, strict=True)
+    )
+
+
+def _set_submodule(root: nn.Module, path: str, replacement: nn.Module) -> None:
+    parent_path, _, child_name = path.rpartition(".")
+    parent = root.get_submodule(parent_path) if parent_path else root
+    if isinstance(parent, (nn.ModuleList, nn.Sequential)) and child_name.isdigit():
+        parent[int(child_name)] = replacement
+    else:
+        setattr(parent, child_name, replacement)
+
+
+def _module_device(module: nn.Module) -> torch.device:
+    parameter = next(module.parameters(recurse=False), None)
+    if parameter is not None:
+        return parameter.device
+    parameter = next(module.parameters(), None)
+    if parameter is not None:
+        return parameter.device
+    return torch.device("cpu")
+
+
+register_adapter(ManifestAdapter())

--- a/src/nunchaku_lite/adapters/manifest.py
+++ b/src/nunchaku_lite/adapters/manifest.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 from ..core import PatchOptions, register_adapter
 from ..linear import AWQW4A16Linear, SVDQW4A4Linear
 from ..manifest import RuntimeManifest, RuntimeManifestTarget, parse_runtime_manifest
-from .common import SVDQPatchContext, finalize_svdq_checkpoint, prepare_transformer_dtype
+from .common import SVDQPatchContext, _mark_patched_module, finalize_svdq_checkpoint, prepare_transformer_dtype
 
 
 class ManifestAdapter:
@@ -187,7 +187,7 @@ def _apply_structural_patches(transformer: nn.Module, manifest: RuntimeManifest)
                 replacement = SplitLinearOutput.from_linear(module, splits)
             else:
                 raise ValueError(f"Unsupported runtime_manifest structural patch type {patch_type!r}.")
-            _set_submodule(transformer, module_name, replacement)
+            _set_submodule(transformer, module_name, _mark_manifest_replacement(replacement))
 
 
 def _replace_target(transformer: nn.Module, target: RuntimeManifestTarget, context: SVDQPatchContext) -> None:
@@ -245,7 +245,7 @@ def _replace_target(transformer: nn.Module, target: RuntimeManifestTarget, conte
     else:
         raise ValueError(f"Unsupported runtime_manifest nunchaku_op {target.nunchaku_op!r}.")
 
-    _set_submodule(transformer, target.checkpoint_prefix, replacement)
+    _set_submodule(transformer, target.checkpoint_prefix, _mark_manifest_replacement(replacement))
 
 
 def _replace_adanorm_awq_target(
@@ -266,8 +266,16 @@ def _replace_adanorm_awq_target(
         torch_dtype=context.torch_dtype,
         device=_module_device(module),
     )
-    wrapped = ManifestAdaNormAWQW4A16(parent, replacement, splits=target.op_options["adanorm_splits"])
-    _set_submodule(transformer, parent_path, wrapped)
+    wrapped = ManifestAdaNormAWQW4A16(
+        parent,
+        _mark_manifest_replacement(replacement),
+        splits=target.op_options["adanorm_splits"],
+    )
+    _set_submodule(transformer, parent_path, _mark_manifest_replacement(wrapped))
+
+
+def _mark_manifest_replacement(module: nn.Module) -> nn.Module:
+    return _mark_patched_module(module)
 
 
 def _validate_svdq_group_size(target: RuntimeManifestTarget) -> None:

--- a/src/nunchaku_lite/adapters/manifest.py
+++ b/src/nunchaku_lite/adapters/manifest.py
@@ -44,8 +44,27 @@ class ManifestAdapter:
             _replace_target(transformer, target, context)
 
         finalize_svdq_checkpoint(transformer, checkpoint_state, context)
+        transformer._nunchaku_lite_runtime_manifest = manifest
+        _bind_manifest_runtime_apis(transformer)
         transformer._nunchaku_lite_manifest_patched = True
         return checkpoint_state
+
+    def patch_pipeline(
+        self,
+        pipeline: Any,
+        *,
+        component_name: str = "transformer",
+        component: torch.nn.Module | None = None,
+    ) -> None:
+        """Attach generic manifest pipeline-level runtime LoRA APIs."""
+
+        component = component if component is not None else getattr(pipeline, component_name, None)
+        if not callable(getattr(component, "load_lora", None)):
+            return
+
+        from ..lora.core.runtime import NunchakuPipelineLoraMixin, bind_pipeline_lora_methods
+
+        bind_pipeline_lora_methods(pipeline, NunchakuPipelineLoraMixin, component_name=component_name)
 
 
 class SplitLinearInput(nn.Module):
@@ -350,6 +369,13 @@ def _module_device(module: nn.Module) -> torch.device:
     if parameter is not None:
         return parameter.device
     return torch.device("cpu")
+
+
+def _bind_manifest_runtime_apis(transformer: nn.Module) -> None:
+    from ..lora.core.runtime import bind_transformer_lora_methods
+    from ..lora.manifest import NunchakuManifestLoraMixin
+
+    bind_transformer_lora_methods(transformer, NunchakuManifestLoraMixin)
 
 
 register_adapter(ManifestAdapter())

--- a/src/nunchaku_lite/adapters/manifest.py
+++ b/src/nunchaku_lite/adapters/manifest.py
@@ -119,6 +119,45 @@ class SplitLinearOutput(nn.Module):
         return torch.cat([linear(x) for linear in self.linears], dim=-1)
 
 
+class ManifestAdaNormAWQW4A16(nn.Module):
+    """Manifest-driven AdaNorm wrapper for interleaved AWQ W4A16 modulation."""
+
+    def __init__(self, parent: nn.Module, linear: nn.Module, *, splits: int) -> None:
+        super().__init__()
+        if splits not in {3, 6}:
+            raise ValueError(f"ManifestAdaNormAWQW4A16 requires splits to be 3 or 6, got {splits}.")
+        missing = [name for name in ("silu", "norm") if not hasattr(parent, name)]
+        if missing:
+            raise TypeError(f"adanorm_awq_w4a16 parent is missing required attributes: {', '.join(missing)}.")
+        self.splits = splits
+        self.emb = getattr(parent, "emb", None)
+        self.silu = parent.silu
+        self.linear = linear
+        self.norm = parent.norm
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        timestep: torch.Tensor | None = None,
+        class_labels: torch.LongTensor | None = None,
+        hidden_dtype: torch.dtype | None = None,
+        emb: torch.Tensor | None = None,
+    ):
+        if self.emb is not None:
+            emb = self.emb(timestep, class_labels, hidden_dtype=hidden_dtype)
+        if emb is None:
+            raise ValueError("adanorm_awq_w4a16 requires an embedding tensor.")
+        emb = self.linear(self.silu(emb))
+        emb = emb.view(emb.shape[0], -1, self.splits).permute(2, 0, 1)
+        if self.splits == 6:
+            shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = emb
+            norm_x = self.norm(x) * scale_msa[:, None] + shift_msa[:, None]
+            return norm_x, gate_msa, shift_mlp, scale_mlp - 1, gate_mlp
+        shift_msa, scale_msa, gate_msa = emb
+        norm_x = self.norm(x) * scale_msa[:, None] + shift_msa[:, None]
+        return norm_x, gate_msa
+
+
 def _manifest_context(transformer: nn.Module, manifest: RuntimeManifest, options: PatchOptions) -> SVDQPatchContext:
     parameter = next(transformer.parameters(), None)
     torch_dtype = options.torch_dtype or (parameter.dtype if parameter is not None else torch.bfloat16)
@@ -187,7 +226,7 @@ def _replace_target(transformer: nn.Module, target: RuntimeManifestTarget, conte
             torch_dtype=context.torch_dtype,
             device=_module_device(module),
         )
-    elif target.nunchaku_op in {"awq_w4a16", "adanorm_awq_w4a16"}:
+    elif target.nunchaku_op == "awq_w4a16":
         if target.precision != "int4":
             raise ValueError(f"{target.nunchaku_op} target {target.checkpoint_prefix!r} requires precision='int4'.")
         replacement = AWQW4A16Linear(
@@ -198,10 +237,37 @@ def _replace_target(transformer: nn.Module, target: RuntimeManifestTarget, conte
             torch_dtype=context.torch_dtype,
             device=_module_device(module),
         )
+    elif target.nunchaku_op == "adanorm_awq_w4a16":
+        if target.precision != "int4":
+            raise ValueError(f"{target.nunchaku_op} target {target.checkpoint_prefix!r} requires precision='int4'.")
+        _replace_adanorm_awq_target(transformer, target, module, context)
+        return
     else:
         raise ValueError(f"Unsupported runtime_manifest nunchaku_op {target.nunchaku_op!r}.")
 
     _set_submodule(transformer, target.checkpoint_prefix, replacement)
+
+
+def _replace_adanorm_awq_target(
+    transformer: nn.Module,
+    target: RuntimeManifestTarget,
+    module: nn.Module,
+    context: SVDQPatchContext,
+) -> None:
+    parent_path, separator, child_name = target.checkpoint_prefix.rpartition(".")
+    if separator == "" or child_name != "linear":
+        raise ValueError(f"adanorm_awq_w4a16 target {target.checkpoint_prefix!r} must reference a '.linear' child.")
+    parent = transformer.get_submodule(parent_path)
+    replacement = AWQW4A16Linear(
+        in_features=module.in_features,
+        out_features=module.out_features,
+        bias=target.has_bias,
+        group_size=target.group_size,
+        torch_dtype=context.torch_dtype,
+        device=_module_device(module),
+    )
+    wrapped = ManifestAdaNormAWQW4A16(parent, replacement, splits=target.op_options["adanorm_splits"])
+    _set_submodule(transformer, parent_path, wrapped)
 
 
 def _validate_svdq_group_size(target: RuntimeManifestTarget) -> None:

--- a/src/nunchaku_lite/core.py
+++ b/src/nunchaku_lite/core.py
@@ -11,6 +11,7 @@ from typing import Any, Protocol
 
 import torch
 
+from .manifest import RuntimeManifest, parse_runtime_manifest
 from .utils import get_precision, load_state_dict_in_safetensors
 
 
@@ -273,10 +274,11 @@ def _patch_component(
             return transformer
         raise ValueError(f"Transformer is already patched as {existing_target!r}; requested {target!r}.")
 
-    adapter = _select_adapter(transformer, target)
     state_dict, metadata = load_state_dict_in_safetensors(checkpoint, return_metadata=True)
     quantization_config = _parse_json_metadata(metadata, "quantization_config")
-    normalized_precision = _normalize_precision(precision, device, checkpoint)
+    runtime_manifest = parse_runtime_manifest(quantization_config)
+    adapter = _select_adapter_for_checkpoint(transformer, target, runtime_manifest)
+    normalized_precision = _normalize_precision(precision, device, checkpoint, runtime_manifest)
     _validate_quantization_compatibility(quantization_config, normalized_precision, device, checkpoint)
     options = PatchOptions(
         precision=normalized_precision,
@@ -301,6 +303,7 @@ def _patch_component(
     transformer._nunchaku_lite_target = adapter.target
     transformer._nunchaku_lite_adapter = adapter
     transformer._nunchaku_lite_quantization_config = quantization_config
+    transformer._nunchaku_lite_runtime_manifest = runtime_manifest
     transformer._nunchaku_lite_incompatible_keys = incompatible
     return transformer
 
@@ -499,7 +502,12 @@ def _parse_json_metadata(metadata: dict[str, str] | None, key: str) -> dict[str,
     return parsed
 
 
-def _normalize_precision(precision: str, device: str | torch.device | None, checkpoint: str | Path) -> str:
+def _normalize_precision(
+    precision: str,
+    device: str | torch.device | None,
+    checkpoint: str | Path,
+    runtime_manifest: RuntimeManifest | None = None,
+) -> str:
     """Resolve public precision options to native kernel precision names.
 
     Args:
@@ -511,7 +519,10 @@ def _normalize_precision(precision: str, device: str | torch.device | None, chec
         ``"int4"`` or native ``"nvfp4"``.
     """
 
-    selected = get_precision(precision=precision, device=device or "cuda", pretrained_model_name_or_path=checkpoint)
+    if precision == "auto" and runtime_manifest is not None and runtime_manifest.precision is not None:
+        selected = runtime_manifest.precision
+    else:
+        selected = get_precision(precision=precision, device=device or "cuda", pretrained_model_name_or_path=checkpoint)
     if selected == "fp4":
         return "nvfp4"
     return selected
@@ -559,6 +570,16 @@ def _validate_quantization_compatibility(
 
 
 def _precision_from_quantization_config(quantization_config: dict[str, Any]) -> str | None:
+    runtime_manifest = quantization_config.get("runtime_manifest")
+    if isinstance(runtime_manifest, dict):
+        requirements = runtime_manifest.get("requirements")
+        if isinstance(requirements, dict):
+            precision = requirements.get("precision")
+            if precision == "int4":
+                return "int4"
+            if precision == "fp4":
+                return "nvfp4"
+
     weight_config = quantization_config.get("weight")
     if not isinstance(weight_config, dict):
         return None
@@ -568,6 +589,22 @@ def _precision_from_quantization_config(quantization_config: dict[str, Any]) -> 
     if weight_dtype == "fp4_e2m1_all":
         return "nvfp4"
     return None
+
+
+def _select_adapter_for_checkpoint(
+    transformer: torch.nn.Module,
+    target: str,
+    runtime_manifest: RuntimeManifest | None,
+) -> TransformerAdapter:
+    if target == "manifest":
+        if runtime_manifest is None:
+            raise ValueError("target='manifest' requires quantization_config.runtime_manifest metadata.")
+        return _ADAPTERS["manifest"]
+
+    if target == "auto" and runtime_manifest is not None:
+        return _ADAPTERS["manifest"]
+
+    return _select_adapter(transformer, target)
 
 
 def _select_adapter(transformer: torch.nn.Module, target: str) -> TransformerAdapter:
@@ -621,6 +658,7 @@ def _ensure_builtin_adapters() -> None:
         return
     importlib.import_module("nunchaku_lite.adapters.flux")
     importlib.import_module("nunchaku_lite.adapters.flux2")
+    importlib.import_module("nunchaku_lite.adapters.manifest")
     importlib.import_module("nunchaku_lite.adapters.qwen_image")
     importlib.import_module("nunchaku_lite.adapters.sdxl")
     importlib.import_module("nunchaku_lite.adapters.z_image")

--- a/src/nunchaku_lite/lora/manifest.py
+++ b/src/nunchaku_lite/lora/manifest.py
@@ -1,0 +1,434 @@
+"""Generic runtime LoRA conversion for manifest-patched transformers."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from torch import nn
+
+from ..linear import AWQW4A16Linear, SVDQW4A4Linear
+from ..manifest import RuntimeManifest, RuntimeManifestTarget
+from .core.convert import (
+    LORA_ERROR_LABEL,
+    is_nunchaku_lite_lora_state_dict,
+    normalize_nunchaku_lora_state_dict,
+    set_standard_converted_lora_pair,
+)
+from .core.layout import lora_modules
+from .core.peft import (
+    LORA_A_SUFFIX,
+    LORA_B_SUFFIX,
+    apply_network_alphas,
+    extract_network_alphas,
+    normalize_float_tensor,
+    peft_lora_pairs,
+)
+from .core.runtime import NunchakuLoraMixin, load_lora_state_dict, raise_if_text_encoder_lora
+
+
+KOHYA_DOWN_SUFFIX = ".lora_down.weight"
+KOHYA_UP_SUFFIX = ".lora_up.weight"
+ALPHA_SUFFIX = ".alpha"
+NUNCHAKU_FORMAT = "nunchaku"
+PEFT_FORMAT = "peft"
+KOHYA_FORMAT = "kohya"
+COMFYUI_FORMAT = "comfyui"
+
+
+@dataclass(frozen=True)
+class _ManifestLoraMatch:
+    target_name: str
+    source_name: str | None
+
+
+class NunchakuManifestLoraMixin(NunchakuLoraMixin):
+    """Mixin-style LoRA runtime for manifest-declared quantized targets."""
+
+    def _convert_lora_to_nunchaku(
+        self,
+        path_or_state_dict: str | Path | dict[str, torch.Tensor],
+    ) -> dict[str, torch.Tensor]:
+        """Convert supported generic LoRA inputs into Nunchaku Lite tensors."""
+
+        state_dict = load_lora_state_dict(path_or_state_dict)
+        return convert_manifest_lora_state_dict(state_dict, self)
+
+
+def convert_manifest_lora_state_dict(
+    state_dict: dict[str, torch.Tensor],
+    transformer: nn.Module,
+) -> dict[str, torch.Tensor]:
+    """Detect a manifest LoRA format, then dispatch to its converter."""
+
+    lora_format = detect_manifest_lora_format(state_dict)
+    if lora_format == NUNCHAKU_FORMAT:
+        return normalize_nunchaku_lora_state_dict(state_dict, transformer)
+    if lora_format == PEFT_FORMAT:
+        return convert_manifest_peft_lora_state_dict(state_dict, transformer)
+    if lora_format == KOHYA_FORMAT:
+        return convert_manifest_kohya_lora_state_dict(state_dict, transformer)
+    if lora_format == COMFYUI_FORMAT:
+        return convert_manifest_comfyui_lora_state_dict(state_dict, transformer)
+    raise ValueError(f"Unsupported manifest LoRA format {lora_format!r}.")
+
+
+def detect_manifest_lora_format(state_dict: dict[str, torch.Tensor]) -> str:
+    """Return the supported manifest LoRA format for a state dict."""
+
+    if is_nunchaku_lite_lora_state_dict(state_dict):
+        return NUNCHAKU_FORMAT
+
+    tensor_keys = [key for key, value in state_dict.items() if torch.is_tensor(value)]
+    has_kohya = any(key.endswith((KOHYA_DOWN_SUFFIX, KOHYA_UP_SUFFIX)) for key in tensor_keys)
+    has_comfyui = any(_is_comfyui_lora_key(key) for key in tensor_keys)
+    has_peft = any(key.endswith((LORA_A_SUFFIX, LORA_B_SUFFIX)) for key in tensor_keys)
+
+    if has_kohya:
+        return KOHYA_FORMAT
+    if has_comfyui:
+        return COMFYUI_FORMAT
+    if has_peft:
+        return PEFT_FORMAT
+    raise ValueError(f"LoRA state dict did not contain any supported {LORA_ERROR_LABEL} projection tensors.")
+
+
+def convert_manifest_peft_lora_state_dict(
+    state_dict: dict[str, torch.Tensor],
+    transformer: nn.Module,
+) -> dict[str, torch.Tensor]:
+    """Convert PEFT/Diffusers-style LoRA keys through manifest targets."""
+
+    normalized = normalize_manifest_peft_lora_state_dict(state_dict)
+    return _convert_manifest_peft_pairs(normalized, transformer)
+
+
+def convert_manifest_kohya_lora_state_dict(
+    state_dict: dict[str, torch.Tensor],
+    transformer: nn.Module,
+) -> dict[str, torch.Tensor]:
+    """Convert Kohya-style LoRA suffixes through manifest targets."""
+
+    normalized = normalize_manifest_kohya_lora_state_dict(state_dict)
+    return _convert_manifest_peft_pairs(normalized, transformer)
+
+
+def convert_manifest_comfyui_lora_state_dict(
+    state_dict: dict[str, torch.Tensor],
+    transformer: nn.Module,
+) -> dict[str, torch.Tensor]:
+    """Convert ComfyUI-style component-prefixed LoRA keys through manifest targets."""
+
+    normalized = normalize_manifest_comfyui_lora_state_dict(state_dict)
+    return _convert_manifest_peft_pairs(normalized, transformer)
+
+
+def _convert_manifest_peft_pairs(
+    normalized_state_dict: dict[str, torch.Tensor],
+    transformer: nn.Module,
+) -> dict[str, torch.Tensor]:
+    """Map normalized PEFT-style pairs to manifest runtime targets."""
+
+    manifest = getattr(transformer, "_nunchaku_lite_runtime_manifest", None)
+    if manifest is None:
+        raise RuntimeError("Manifest LoRA conversion requires _nunchaku_lite_runtime_manifest on the transformer.")
+    raise_if_text_encoder_lora(normalized_state_dict)
+
+    alphas = extract_network_alphas(normalized_state_dict)
+    pairs = peft_lora_pairs(apply_network_alphas(normalized_state_dict, alphas))
+    if not pairs:
+        raise ValueError(f"LoRA state dict did not contain any supported {LORA_ERROR_LABEL} projection tensors.")
+
+    modules = lora_modules(transformer)
+    target_index = {target.checkpoint_prefix: target for target in manifest.targets}
+    alias_index = _build_manifest_lora_alias_index(manifest)
+    grouped: dict[str, list[tuple[str | None, str, torch.Tensor, torch.Tensor]]] = defaultdict(list)
+    unsupported = []
+
+    for base_name, (lora_a, lora_b) in pairs.items():
+        match = _resolve_manifest_lora_base(base_name, alias_index)
+        if match is None:
+            unsupported.append(base_name)
+            continue
+        grouped[match.target_name].append((match.source_name, base_name, lora_a, lora_b))
+
+    if unsupported:
+        sample = ", ".join(unsupported[:5])
+        raise ValueError(f"Unsupported {LORA_ERROR_LABEL} target(s) for manifest runtime: {sample}")
+
+    converted: dict[str, torch.Tensor] = {}
+    for target_name, entries in grouped.items():
+        if target_name not in modules:
+            raise ValueError(
+                f"Manifest LoRA target {target_name!r} does not exist on this patched {LORA_ERROR_LABEL} transformer."
+            )
+        target = target_index[target_name]
+        module = modules[target_name]
+        down, up = _convert_manifest_target_entries(target, module, entries)
+        set_standard_converted_lora_pair(converted, target_name, down, up, module)
+    return converted
+
+
+def normalize_manifest_peft_lora_state_dict(
+    state_dict: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    """Normalize PEFT/Diffusers LoRA keys while preserving target bases."""
+
+    normalized: dict[str, torch.Tensor] = {}
+    for key, value in state_dict.items():
+        if not torch.is_tensor(value):
+            continue
+        if key.endswith(LORA_A_SUFFIX):
+            base = key[: -len(LORA_A_SUFFIX)]
+            normalized[f"{_strip_common_lora_prefixes(base)}{LORA_A_SUFFIX}"] = normalize_float_tensor(value)
+        elif key.endswith(LORA_B_SUFFIX):
+            base = key[: -len(LORA_B_SUFFIX)]
+            normalized[f"{_strip_common_lora_prefixes(base)}{LORA_B_SUFFIX}"] = normalize_float_tensor(value)
+        elif key.endswith(ALPHA_SUFFIX):
+            base = key[: -len(ALPHA_SUFFIX)]
+            normalized[f"{_strip_common_lora_prefixes(base)}{ALPHA_SUFFIX}"] = value
+    return normalized
+
+
+def normalize_manifest_kohya_lora_state_dict(
+    state_dict: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    """Normalize Kohya ``lora_down/lora_up`` keys to PEFT pair suffixes."""
+
+    normalized: dict[str, torch.Tensor] = {}
+    for key, value in state_dict.items():
+        if not torch.is_tensor(value):
+            continue
+        if key.endswith(KOHYA_DOWN_SUFFIX):
+            base = key[: -len(KOHYA_DOWN_SUFFIX)]
+            normalized[f"{_strip_common_lora_prefixes(base)}{LORA_A_SUFFIX}"] = normalize_float_tensor(value)
+        elif key.endswith(KOHYA_UP_SUFFIX):
+            base = key[: -len(KOHYA_UP_SUFFIX)]
+            normalized[f"{_strip_common_lora_prefixes(base)}{LORA_B_SUFFIX}"] = normalize_float_tensor(value)
+        elif key.endswith(ALPHA_SUFFIX):
+            base = key[: -len(ALPHA_SUFFIX)]
+            normalized[f"{_strip_common_lora_prefixes(base)}{ALPHA_SUFFIX}"] = value
+    return normalized
+
+
+def normalize_manifest_comfyui_lora_state_dict(
+    state_dict: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    """Normalize ComfyUI component-prefixed LoRA keys to PEFT pair suffixes."""
+
+    normalized: dict[str, torch.Tensor] = {}
+    for key, value in state_dict.items():
+        if not torch.is_tensor(value):
+            continue
+        if key.endswith(LORA_A_SUFFIX):
+            base = key[: -len(LORA_A_SUFFIX)]
+            normalized[f"{_strip_common_lora_prefixes(base)}{LORA_A_SUFFIX}"] = normalize_float_tensor(value)
+        elif key.endswith(LORA_B_SUFFIX):
+            base = key[: -len(LORA_B_SUFFIX)]
+            normalized[f"{_strip_common_lora_prefixes(base)}{LORA_B_SUFFIX}"] = normalize_float_tensor(value)
+        elif key.endswith(KOHYA_DOWN_SUFFIX):
+            base = key[: -len(KOHYA_DOWN_SUFFIX)]
+            normalized[f"{_strip_common_lora_prefixes(base)}{LORA_A_SUFFIX}"] = normalize_float_tensor(value)
+        elif key.endswith(KOHYA_UP_SUFFIX):
+            base = key[: -len(KOHYA_UP_SUFFIX)]
+            normalized[f"{_strip_common_lora_prefixes(base)}{LORA_B_SUFFIX}"] = normalize_float_tensor(value)
+        elif key.endswith(ALPHA_SUFFIX):
+            base = key[: -len(ALPHA_SUFFIX)]
+            normalized[f"{_strip_common_lora_prefixes(base)}{ALPHA_SUFFIX}"] = value
+    return normalized
+
+
+def _convert_manifest_target_entries(
+    target: RuntimeManifestTarget,
+    module: SVDQW4A4Linear | AWQW4A16Linear,
+    entries: list[tuple[str | None, str, torch.Tensor, torch.Tensor]],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    direct_entries = [entry for entry in entries if entry[0] is None or entry[0] == target.checkpoint_prefix]
+    if direct_entries:
+        if len(direct_entries) > 1:
+            bases = ", ".join(entry[1] for entry in direct_entries[:5])
+            raise ValueError(f"Ambiguous manifest LoRA entries for {target.checkpoint_prefix!r}: {bases}")
+        _source, _base, lora_a, lora_b = direct_entries[0]
+        return lora_a.contiguous(), lora_b.contiguous()
+
+    source_order = list(target.source_modules)
+    if len(source_order) <= 1:
+        _source, _base, lora_a, lora_b = entries[0]
+        return lora_a.contiguous(), lora_b.contiguous()
+
+    by_source: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+    for source_name, base_name, lora_a, lora_b in entries:
+        if source_name is None:
+            continue
+        if source_name in by_source:
+            raise ValueError(f"Multiple LoRA pairs map to manifest source module {source_name!r}: {base_name}")
+        by_source[source_name] = (lora_a, lora_b)
+    return _fuse_manifest_source_branches(target, module, by_source)
+
+
+def _fuse_manifest_source_branches(
+    target: RuntimeManifestTarget,
+    module: SVDQW4A4Linear | AWQW4A16Linear,
+    by_source: dict[str, tuple[torch.Tensor, torch.Tensor]],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    source_order = list(target.source_modules)
+    if not source_order:
+        raise ValueError(f"Manifest target {target.checkpoint_prefix!r} has no source_modules for LoRA fusion.")
+    if module.out_features % len(source_order) != 0:
+        raise ValueError(
+            f"Cannot infer equal branch sizes for manifest LoRA target {target.checkpoint_prefix!r} "
+            f"with out_features={module.out_features} and {len(source_order)} source modules."
+        )
+
+    observed = [(source_name, by_source[source_name]) for source_name in source_order if source_name in by_source]
+    if not observed:
+        raise ValueError(f"No LoRA branches were provided for manifest target {target.checkpoint_prefix!r}.")
+
+    branch_out = module.out_features // len(source_order)
+    first_a, first_b = observed[0][1]
+    for source_name, (lora_a, lora_b) in observed:
+        if lora_a.shape[1] != module.in_features:
+            raise ValueError(
+                f"LoRA A tensor for {source_name!r} has input size {lora_a.shape[1]}, "
+                f"expected {module.in_features}."
+            )
+        if lora_b.shape[0] > branch_out:
+            raise ValueError(
+                f"LoRA B tensor for {source_name!r} has output size {lora_b.shape[0]}, "
+                f"but inferred branch size is {branch_out}."
+            )
+
+    if all(lora_a.equal(first_a) for _source_name, (lora_a, _lora_b) in observed):
+        up_branches = []
+        for source_name in source_order:
+            pair = by_source.get(source_name)
+            if pair is None:
+                up_branches.append(
+                    torch.zeros(branch_out, first_a.shape[0], dtype=first_b.dtype, device=first_b.device)
+                )
+                continue
+            _lora_a, lora_b = pair
+            if lora_b.shape[0] < branch_out:
+                padded = torch.zeros(branch_out, lora_b.shape[1], dtype=lora_b.dtype, device=lora_b.device)
+                padded[: lora_b.shape[0]] = lora_b
+                lora_b = padded
+            up_branches.append(lora_b)
+        return first_a.contiguous(), torch.cat(up_branches, dim=0).contiguous()
+
+    total_rank = sum(lora_a.shape[0] for _source_name, (lora_a, _lora_b) in observed)
+    down = torch.zeros(total_rank, module.in_features, dtype=first_a.dtype, device=first_a.device)
+    up = torch.zeros(module.out_features, total_rank, dtype=first_b.dtype, device=first_b.device)
+    col = 0
+    for source_index, source_name in enumerate(source_order):
+        pair = by_source.get(source_name)
+        if pair is None:
+            continue
+        lora_a, lora_b = pair
+        rank = lora_a.shape[0]
+        down[col : col + rank] = lora_a
+        row = source_index * branch_out
+        up[row : row + lora_b.shape[0], col : col + rank] = lora_b
+        col += rank
+    return down.contiguous(), up.contiguous()
+
+
+def _build_manifest_lora_alias_index(manifest: RuntimeManifest) -> dict[str, set[_ManifestLoraMatch]]:
+    index: dict[str, set[_ManifestLoraMatch]] = defaultdict(set)
+    for target in manifest.targets:
+        for path in (target.checkpoint_prefix, target.name):
+            if path:
+                _add_manifest_lora_aliases(index, path, _ManifestLoraMatch(target.checkpoint_prefix, None))
+        for source_name in target.source_modules:
+            source = None if source_name == target.checkpoint_prefix else source_name
+            _add_manifest_lora_aliases(index, source_name, _ManifestLoraMatch(target.checkpoint_prefix, source))
+    return index
+
+
+def _add_manifest_lora_aliases(
+    index: dict[str, set[_ManifestLoraMatch]],
+    path: str,
+    match: _ManifestLoraMatch,
+) -> None:
+    for alias in _manifest_lora_aliases(path):
+        index[alias].add(match)
+
+
+def _manifest_lora_aliases(path: str) -> set[str]:
+    stripped = _strip_common_lora_prefixes(path)
+    aliases = {path, stripped}
+    aliases.update(
+        {
+            f"transformer.{stripped}",
+            f"base_model.model.transformer.{stripped}",
+            f"diffusion_model.{stripped}",
+        }
+    )
+    compressed = stripped.replace(".", "_")
+    aliases.update(
+        {
+            compressed,
+            f"lora_transformer_{compressed}",
+            f"lora_diffusion_model_{compressed}",
+        }
+    )
+    return aliases
+
+
+def _resolve_manifest_lora_base(
+    base_name: str,
+    alias_index: dict[str, set[_ManifestLoraMatch]],
+) -> _ManifestLoraMatch | None:
+    candidates: set[_ManifestLoraMatch] = set()
+    for alias in _base_lookup_aliases(base_name):
+        candidates.update(alias_index.get(alias, set()))
+    if not candidates:
+        return None
+
+    direct = {candidate for candidate in candidates if candidate.source_name is None}
+    if direct:
+        candidates = direct
+    if len(candidates) == 1:
+        return next(iter(candidates))
+    sample = ", ".join(
+        f"{candidate.target_name}:{candidate.source_name or '<direct>'}"
+        for candidate in sorted(candidates, key=lambda item: (item.target_name, item.source_name or ""))
+    )
+    raise ValueError(f"Ambiguous manifest LoRA target {base_name!r}; matched {sample}.")
+
+
+def _base_lookup_aliases(base_name: str) -> set[str]:
+    stripped = _strip_common_lora_prefixes(base_name)
+    aliases = {base_name, stripped}
+    if stripped.startswith("lora_transformer_"):
+        aliases.add(stripped[len("lora_transformer_") :])
+    if stripped.startswith("lora_diffusion_model_"):
+        aliases.add(stripped[len("lora_diffusion_model_") :])
+    return aliases
+
+
+def _is_comfyui_lora_key(key: str) -> bool:
+    return key.startswith(
+        (
+            "diffusion_model.",
+            "model.diffusion_model.",
+            "base_model.model.diffusion_model.",
+            "lora_diffusion_model_",
+        )
+    )
+
+
+def _strip_common_lora_prefixes(base_name: str) -> str:
+    prefixes = (
+        "base_model.model.transformer.",
+        "base_model.model.diffusion_model.",
+        "base_model.model.",
+        "model.diffusion_model.",
+        "diffusion_model.",
+        "transformer.",
+    )
+    for prefix in prefixes:
+        if base_name.startswith(prefix):
+            return base_name[len(prefix) :]
+    return base_name

--- a/src/nunchaku_lite/manifest.py
+++ b/src/nunchaku_lite/manifest.py
@@ -1,0 +1,218 @@
+"""Runtime manifest parsing for Nunchaku Lite checkpoint metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+SCHEMA = "nunchaku_lite.runtime_manifest"
+SUPPORTED_VERSION = 1
+SUPPORTED_FORMAT_VERSION = 1
+SUPPORTED_OPS = {"svdq_w4a4", "awq_w4a16", "adanorm_awq_w4a16"}
+SUPPORTED_PRECISIONS = {"int4", "fp4"}
+SUPPORTED_KINDS = {"linear"}
+
+
+@dataclass(frozen=True)
+class RuntimeManifestTarget:
+    """One runtime target declared by a Nunchaku Lite manifest."""
+
+    name: str | None
+    checkpoint_prefix: str
+    source_modules: tuple[str, ...]
+    roles: tuple[str, ...]
+    kind: str
+    nunchaku_op: str
+    precision: str
+    group_size: int
+    rank: int
+    has_bias: bool
+    op_options: dict[str, Any] = field(default_factory=dict)
+    activation: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def runtime_precision(self) -> str:
+        """Return the native precision name used by runtime modules."""
+
+        return "nvfp4" if self.precision == "fp4" else self.precision
+
+
+@dataclass(frozen=True)
+class RuntimeManifest:
+    """Validated v1 Nunchaku Lite runtime manifest."""
+
+    schema: str
+    version: int
+    component: str
+    nunchaku_format_version: int
+    producer: dict[str, Any]
+    requirements: dict[str, Any]
+    structural_patches: tuple[dict[str, Any], ...]
+    targets: tuple[RuntimeManifestTarget, ...]
+
+    @property
+    def precision(self) -> str | None:
+        """Return the common manifest precision, or ``None`` for mixed."""
+
+        precision = self.requirements.get("precision")
+        if precision in SUPPORTED_PRECISIONS:
+            return str(precision)
+        return None
+
+    @property
+    def runtime_precision(self) -> str | None:
+        """Return the common native precision, or ``None`` for mixed."""
+
+        precision = self.precision
+        if precision is None:
+            return None
+        return "nvfp4" if precision == "fp4" else precision
+
+    @property
+    def rank(self) -> int:
+        """Return the common rank declared in requirements."""
+
+        return int(self.requirements.get("rank", 32))
+
+
+def parse_runtime_manifest(quantization_config: dict[str, Any]) -> RuntimeManifest | None:
+    """Parse and validate ``quantization_config.runtime_manifest`` if present."""
+
+    raw = quantization_config.get("runtime_manifest")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError("quantization_config.runtime_manifest must be a JSON object.")
+
+    schema = _required(raw, "schema", str)
+    if schema != SCHEMA:
+        raise ValueError(f"Unsupported runtime_manifest schema {schema!r}; expected {SCHEMA!r}.")
+
+    version = _required(raw, "version", int)
+    if version != SUPPORTED_VERSION:
+        raise ValueError(f"Unsupported runtime_manifest version {version}; expected {SUPPORTED_VERSION}.")
+
+    nunchaku_format_version = _required(raw, "nunchaku_format_version", int)
+    if nunchaku_format_version != SUPPORTED_FORMAT_VERSION:
+        raise ValueError(
+            "Unsupported runtime_manifest nunchaku_format_version "
+            f"{nunchaku_format_version}; expected {SUPPORTED_FORMAT_VERSION}."
+        )
+
+    component = _required(raw, "component", str)
+    producer = _required(raw, "producer", dict)
+    requirements = _required(raw, "requirements", dict)
+    _validate_producer(producer)
+    _validate_requirements(requirements)
+    structural_patches = _required(raw, "structural_patches", list)
+    targets_raw = _required(raw, "targets", list)
+    if not targets_raw:
+        raise ValueError("runtime_manifest.targets must contain at least one target.")
+
+    precision = requirements.get("precision")
+    if precision not in (*SUPPORTED_PRECISIONS, "mixed"):
+        raise ValueError(f"Unsupported runtime_manifest requirements.precision {precision!r}.")
+
+    return RuntimeManifest(
+        schema=schema,
+        version=version,
+        component=component,
+        nunchaku_format_version=nunchaku_format_version,
+        producer=dict(producer),
+        requirements=dict(requirements),
+        structural_patches=tuple(_validate_structural_patch(patch) for patch in structural_patches),
+        targets=tuple(_parse_target(index, target) for index, target in enumerate(targets_raw)),
+    )
+
+
+def _validate_producer(producer: dict[str, Any]) -> None:
+    _required(producer, "name", str)
+    _required(producer, "version", str)
+
+
+def _validate_requirements(requirements: dict[str, Any]) -> None:
+    _required(requirements, "method", str)
+    _required(requirements, "precision", str)
+    _required(requirements, "rank", int)
+    _required(requirements, "weight_dtype", str)
+    _required(requirements, "activation_dtype", str)
+    if "torch_dtype" not in requirements:
+        raise ValueError("runtime_manifest requirements missing required field 'torch_dtype'.")
+
+
+def _parse_target(index: int, raw: Any) -> RuntimeManifestTarget:
+    if not isinstance(raw, dict):
+        raise ValueError(f"runtime_manifest.targets[{index}] must be a JSON object.")
+
+    checkpoint_prefix = _required(raw, "checkpoint_prefix", str)
+    source_modules = _required(raw, "source_modules", list)
+    roles = _required(raw, "roles", list)
+    kind = _required(raw, "kind", str)
+    nunchaku_op = _required(raw, "nunchaku_op", str)
+    precision = _required(raw, "precision", str)
+    group_size = _required(raw, "group_size", int)
+    rank = _required(raw, "rank", int)
+    has_bias = _required(raw, "has_bias", bool)
+    op_options = _required(raw, "op_options", dict)
+    activation = _required(raw, "activation", dict)
+
+    if kind not in SUPPORTED_KINDS:
+        raise ValueError(f"Unsupported runtime_manifest target kind {kind!r} at {checkpoint_prefix!r}.")
+    if nunchaku_op not in SUPPORTED_OPS:
+        raise ValueError(f"Unsupported runtime_manifest nunchaku_op {nunchaku_op!r} at {checkpoint_prefix!r}.")
+    if precision not in SUPPORTED_PRECISIONS:
+        raise ValueError(f"Unsupported runtime_manifest target precision {precision!r} at {checkpoint_prefix!r}.")
+    if group_size <= 0:
+        raise ValueError(f"runtime_manifest target {checkpoint_prefix!r} must have positive group_size.")
+    if rank < 0:
+        raise ValueError(f"runtime_manifest target {checkpoint_prefix!r} must have non-negative rank.")
+    if not all(isinstance(item, str) for item in source_modules):
+        raise ValueError(f"runtime_manifest target {checkpoint_prefix!r} source_modules must be strings.")
+    if not all(isinstance(item, str) for item in roles):
+        raise ValueError(f"runtime_manifest target {checkpoint_prefix!r} roles must be strings.")
+
+    if nunchaku_op == "adanorm_awq_w4a16":
+        splits = op_options.get("adanorm_splits")
+        if not isinstance(splits, int) or splits <= 0:
+            raise ValueError(
+                f"runtime_manifest target {checkpoint_prefix!r} requires positive op_options.adanorm_splits."
+            )
+
+    return RuntimeManifestTarget(
+        name=raw.get("name") if isinstance(raw.get("name"), str) else None,
+        checkpoint_prefix=checkpoint_prefix,
+        source_modules=tuple(source_modules),
+        roles=tuple(roles),
+        kind=kind,
+        nunchaku_op=nunchaku_op,
+        precision=precision,
+        group_size=group_size,
+        rank=rank,
+        has_bias=has_bias,
+        op_options=dict(op_options),
+        activation=dict(activation),
+    )
+
+
+def _validate_structural_patch(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ValueError("runtime_manifest structural patches must be JSON objects.")
+    patch_type = _required(raw, "type", str)
+    if patch_type not in {"split_linear_output", "split_linear_input"}:
+        raise ValueError(f"Unsupported runtime_manifest structural patch type {patch_type!r}.")
+    module = _required(raw, "module", str)
+    args = _required(raw, "args", dict)
+    splits = args.get("splits")
+    if not isinstance(splits, list):
+        raise ValueError(f"runtime_manifest structural patch {module!r} requires args.splits list.")
+    return {"type": patch_type, "module": module, "args": dict(args)}
+
+
+def _required(raw: dict[str, Any], key: str, expected_type: type) -> Any:
+    if key not in raw:
+        raise ValueError(f"runtime_manifest is missing required field {key!r}.")
+    value = raw[key]
+    if not isinstance(value, expected_type):
+        raise ValueError(f"runtime_manifest field {key!r} must be {expected_type.__name__}.")
+    return value

--- a/src/nunchaku_lite/manifest.py
+++ b/src/nunchaku_lite/manifest.py
@@ -174,9 +174,9 @@ def _parse_target(index: int, raw: Any) -> RuntimeManifestTarget:
 
     if nunchaku_op == "adanorm_awq_w4a16":
         splits = op_options.get("adanorm_splits")
-        if not isinstance(splits, int) or splits <= 0:
+        if splits not in {3, 6}:
             raise ValueError(
-                f"runtime_manifest target {checkpoint_prefix!r} requires positive op_options.adanorm_splits."
+                f"runtime_manifest target {checkpoint_prefix!r} requires op_options.adanorm_splits to be 3 or 6."
             )
 
     return RuntimeManifestTarget(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -134,16 +134,18 @@ def test_import_does_not_import_full_nunchaku():
     assert "nunchaku" not in sys.modules
     assert "flux" in nunchaku_lite.list_adapters()
     assert "flux2" in nunchaku_lite.list_adapters()
+    assert "manifest" in nunchaku_lite.list_adapters()
     assert "qwen_image" in nunchaku_lite.list_adapters()
     assert "sdxl" in nunchaku_lite.list_adapters()
     assert "z_image" in nunchaku_lite.list_adapters()
 
 
-def test_unsupported_transformer_error_lists_adapters():
+def test_unsupported_transformer_error_lists_adapters(tmp_path):
     from nunchaku_lite import patch_transformer
 
-    with pytest.raises(ValueError, match="Available adapters: flux, flux2, qwen_image, sdxl, z_image"):
-        patch_transformer(torch.nn.Linear(1, 1), "missing/repo/checkpoint.safetensors")
+    checkpoint = _fake_checkpoint(tmp_path)
+    with pytest.raises(ValueError, match="Available adapters: flux, flux2, manifest, qwen_image, sdxl, z_image"):
+        patch_transformer(torch.nn.Linear(1, 1), checkpoint)
 
 
 def test_load_nunchaku_pipeline_injects_meta_loaded_transformer(tmp_path, monkeypatch):

--- a/tests/test_flux2_adapter.py
+++ b/tests/test_flux2_adapter.py
@@ -6,7 +6,12 @@ from safetensors.torch import save_file
 
 from diffusers import Flux2Transformer2DModel
 from nunchaku_lite import patch_transformer
-from nunchaku_lite.adapters.flux2 import Flux2Adapter, NunchakuFlux2Attention, _pack_flux2_rotary_emb
+from nunchaku_lite.adapters.flux2 import (
+    Flux2Adapter,
+    NunchakuFlux2Attention,
+    _pack_flux2_rotary_emb,
+    convert_flux2_state_dict,
+)
 
 
 def make_tiny_flux2_transformer():
@@ -36,6 +41,39 @@ def test_pack_flux2_rotary_emb_uses_packed_nunchaku_layout():
 
     assert packed.shape == (1, 256, 32)
     assert packed.dtype == torch.float32
+
+
+def test_convert_flux2_state_dict_maps_original_nunchaku_keys():
+    state = {
+        "transformer_blocks.0.qkv_proj.lora_down": torch.empty(1),
+        "transformer_blocks.0.qkv_proj_context.smooth_orig": torch.empty(1),
+        "transformer_blocks.0.out_proj_context.smooth": torch.empty(1),
+        "transformer_blocks.0.mlp_context_fc1.lora_up": torch.empty(1),
+        "single_transformer_blocks.0.qkv_proj.lora_down": torch.empty(1),
+        "single_transformer_blocks.0.mlp_fc2.smooth": torch.empty(1),
+    }
+
+    converted = convert_flux2_state_dict(state)
+
+    assert "transformer_blocks.0.attn.to_qkv.proj_down" in converted
+    assert "transformer_blocks.0.attn.to_added_qkv.smooth_factor_orig" in converted
+    assert "transformer_blocks.0.attn.to_add_out.smooth_factor" in converted
+    assert "transformer_blocks.0.ff_context.linear_in.proj_up" in converted
+    assert "single_transformer_blocks.0.attn.qkv_proj.proj_down" in converted
+    assert "single_transformer_blocks.0.attn.mlp_fc2.smooth_factor" in converted
+
+
+def test_convert_flux2_state_dict_leaves_corrected_keys_unchanged():
+    state = {
+        "transformer_blocks.0.attn.to_qkv.proj_down": torch.empty(1),
+        "transformer_blocks.0.ff_context.linear_in.smooth_factor": torch.empty(1),
+        "single_transformer_blocks.0.attn.qkv_proj.proj_down": torch.empty(1),
+    }
+
+    converted = convert_flux2_state_dict(state)
+
+    assert converted is state
+    assert set(converted) == set(state)
 
 
 def test_patch_transformer_patches_flux2_from_synthetic_checkpoint(tmp_path):

--- a/tests/test_flux_adapter.py
+++ b/tests/test_flux_adapter.py
@@ -45,6 +45,19 @@ def test_convert_flux_state_dict_maps_original_nunchaku_keys():
     assert "single_transformer_blocks.0.attn.to_out.proj_up" in converted
 
 
+def test_convert_flux_state_dict_leaves_corrected_keys_unchanged():
+    state = {
+        "transformer_blocks.0.attn.to_qkv.qweight": torch.empty(1),
+        "transformer_blocks.0.ff_context.net.0.proj.smooth_factor": torch.empty(1),
+        "single_transformer_blocks.0.attn.to_out.proj_up": torch.empty(1),
+    }
+
+    converted = convert_flux_state_dict(state)
+
+    assert converted is state
+    assert set(converted) == set(state)
+
+
 def test_patch_transformer_patches_flux_from_synthetic_checkpoint(tmp_path):
     rank = 4
     source = make_tiny_flux_transformer()

--- a/tests/test_manifest_adapter.py
+++ b/tests/test_manifest_adapter.py
@@ -1,0 +1,233 @@
+import json
+
+import pytest
+import torch
+from safetensors.torch import save_file
+from torch import nn
+
+from nunchaku_lite import patch_transformer
+from nunchaku_lite.adapters.manifest import ManifestAdapter, SplitLinearInput, SplitLinearOutput
+from nunchaku_lite.linear import AWQW4A16Linear, SVDQW4A4Linear
+from nunchaku_lite.manifest import parse_runtime_manifest
+
+
+class TinyManifestModel(nn.Module):
+    def __init__(self, out_features: int = 128):
+        super().__init__()
+        self.proj = nn.Linear(128, out_features)
+
+    def forward(self, x):
+        return self.proj(x)
+
+
+class MatchingFakeAdapter:
+    target = "manifest_fake"
+
+    def matches(self, transformer):
+        return isinstance(transformer, TinyManifestModel)
+
+    def patch(self, transformer, checkpoint_state, quantization_config, options):
+        transformer.fake_adapter_used = True
+        return checkpoint_state
+
+
+def _manifest(*, op="svdq_w4a4", precision="int4", group_size=64, rank=4, patches=None, has_bias=True):
+    return {
+        "schema": "nunchaku_lite.runtime_manifest",
+        "version": 1,
+        "component": "transformer",
+        "nunchaku_format_version": 1,
+        "producer": {"name": "test", "version": "0"},
+        "requirements": {
+            "method": "svdquant",
+            "precision": precision,
+            "rank": rank,
+            "weight_dtype": "fp4_e2m1_all" if precision == "fp4" else "int4",
+            "activation_dtype": "int4",
+            "torch_dtype": None,
+        },
+        "structural_patches": patches or [],
+        "targets": [
+            {
+                "name": "proj",
+                "checkpoint_prefix": "proj",
+                "source_modules": ["proj"],
+                "roles": [],
+                "kind": "linear",
+                "nunchaku_op": op,
+                "precision": precision,
+                "group_size": group_size,
+                "rank": rank,
+                "has_bias": has_bias,
+                "op_options": {"adanorm_splits": 6} if op == "adanorm_awq_w4a16" else {},
+                "activation": {},
+            }
+        ],
+    }
+
+
+def _quantization_config(manifest):
+    return {"runtime_manifest": manifest}
+
+
+def _write_manifest_checkpoint(tmp_path, model, manifest):
+    quantization_config = _quantization_config(manifest)
+    ManifestAdapter().patch(
+        model,
+        {},
+        quantization_config,
+        type(
+            "Options",
+            (),
+            {
+                "precision": parse_runtime_manifest(quantization_config).runtime_precision or "int4",
+                "torch_dtype": torch.bfloat16,
+                "device": None,
+                "strict": True,
+                "adapter_options": {},
+            },
+        )(),
+    )
+    checkpoint = tmp_path / "manifest.safetensors"
+    save_file(
+        model.state_dict(),
+        checkpoint,
+        metadata={"quantization_config": json.dumps(quantization_config)},
+    )
+    return checkpoint
+
+
+def test_parse_runtime_manifest_rejects_unsupported_schema():
+    quantization_config = _quantization_config({**_manifest(), "schema": "other"})
+
+    with pytest.raises(ValueError, match="Unsupported runtime_manifest schema"):
+        parse_runtime_manifest(quantization_config)
+
+
+def test_patch_transformer_manifest_target_replaces_svdq_linear(tmp_path):
+    manifest = _manifest()
+    checkpoint = _write_manifest_checkpoint(tmp_path, TinyManifestModel(), manifest)
+
+    transformer = TinyManifestModel()
+    patch_transformer(
+        transformer,
+        checkpoint,
+        target="manifest",
+        precision="auto",
+        torch_dtype=torch.bfloat16,
+        device="cpu",
+    )
+
+    assert transformer._nunchaku_lite_target == "manifest"
+    assert isinstance(transformer.proj, SVDQW4A4Linear)
+    assert transformer.proj.rank == 4
+    assert transformer.proj.precision == "int4"
+
+
+def test_patch_transformer_auto_uses_manifest_before_matching_adapter(tmp_path, monkeypatch):
+    import nunchaku_lite.core as core
+
+    manifest = _manifest()
+    checkpoint = _write_manifest_checkpoint(tmp_path, TinyManifestModel(), manifest)
+    monkeypatch.setitem(core._ADAPTERS, MatchingFakeAdapter.target, MatchingFakeAdapter())
+
+    transformer = TinyManifestModel()
+    patch_transformer(transformer, checkpoint, target="auto", torch_dtype=torch.bfloat16, device="cpu")
+
+    assert transformer._nunchaku_lite_target == "manifest"
+    assert not hasattr(transformer, "fake_adapter_used")
+
+
+def test_patch_transformer_auto_falls_back_when_manifest_absent(tmp_path, monkeypatch):
+    import nunchaku_lite.core as core
+
+    checkpoint = tmp_path / "dense.safetensors"
+    save_file(
+        TinyManifestModel().state_dict(),
+        checkpoint,
+        metadata={"quantization_config": json.dumps({})},
+    )
+    monkeypatch.setitem(core._ADAPTERS, MatchingFakeAdapter.target, MatchingFakeAdapter())
+
+    transformer = TinyManifestModel()
+    patch_transformer(transformer, checkpoint, target="auto", torch_dtype=torch.bfloat16, device="cpu")
+
+    assert transformer._nunchaku_lite_target == MatchingFakeAdapter.target
+    assert transformer.fake_adapter_used
+
+
+def test_patch_transformer_manifest_target_requires_manifest(tmp_path):
+    checkpoint = tmp_path / "dense.safetensors"
+    save_file(
+        TinyManifestModel().state_dict(),
+        checkpoint,
+        metadata={"quantization_config": json.dumps({})},
+    )
+
+    with pytest.raises(ValueError, match="requires quantization_config.runtime_manifest"):
+        patch_transformer(TinyManifestModel(), checkpoint, target="manifest", torch_dtype=torch.bfloat16, device="cpu")
+
+
+def test_manifest_adapter_applies_split_linear_output_before_replacement(tmp_path):
+    manifest = _manifest(
+        patches=[{"type": "split_linear_output", "module": "proj", "args": {"splits": [64]}}],
+    )
+    source = TinyManifestModel(out_features=128)
+    checkpoint = _write_manifest_checkpoint(tmp_path, source, manifest)
+    assert isinstance(source.proj, SVDQW4A4Linear)
+
+    transformer = TinyManifestModel(out_features=128)
+    ManifestAdapter().patch(
+        transformer,
+        {},
+        _quantization_config(manifest),
+        type(
+            "Options",
+            (),
+            {
+                "precision": "int4",
+                "torch_dtype": torch.bfloat16,
+                "device": None,
+                "strict": True,
+                "adapter_options": {},
+            },
+        )(),
+    )
+
+    assert isinstance(transformer.proj, SVDQW4A4Linear)
+    patch_transformer(
+        TinyManifestModel(out_features=128),
+        checkpoint,
+        target="manifest",
+        torch_dtype=torch.bfloat16,
+        device="cpu",
+    )
+
+
+def test_manifest_structural_patch_classes_preserve_linear_metadata():
+    linear = nn.Linear(128, 128)
+
+    split_input = SplitLinearInput.from_linear(linear, [64])
+    split_output = SplitLinearOutput.from_linear(linear, [64])
+
+    assert split_input.in_features == 128
+    assert split_input.out_features == 128
+    assert split_output.in_features == 128
+    assert split_output.out_features == 128
+
+
+def test_manifest_adapter_replaces_awq_target(tmp_path):
+    manifest = _manifest(op="awq_w4a16", precision="int4", group_size=64, rank=0)
+    checkpoint = _write_manifest_checkpoint(tmp_path, TinyManifestModel(), manifest)
+
+    transformer = TinyManifestModel()
+    patch_transformer(
+        transformer,
+        checkpoint,
+        target="manifest",
+        precision="int4",
+        torch_dtype=torch.bfloat16,
+        device="cpu",
+    )
+
+    assert isinstance(transformer.proj, AWQW4A16Linear)

--- a/tests/test_manifest_adapter.py
+++ b/tests/test_manifest_adapter.py
@@ -12,6 +12,7 @@ from nunchaku_lite.adapters.manifest import (
     SplitLinearInput,
     SplitLinearOutput,
 )
+from nunchaku_lite.adapters.common import PATCHED_MODULE_ATTR
 from nunchaku_lite.linear import AWQW4A16Linear, SVDQW4A4Linear
 from nunchaku_lite.manifest import parse_runtime_manifest
 
@@ -151,6 +152,7 @@ def test_patch_transformer_manifest_target_replaces_svdq_linear(tmp_path):
     assert isinstance(transformer.proj, SVDQW4A4Linear)
     assert transformer.proj.rank == 4
     assert transformer.proj.precision == "int4"
+    assert getattr(transformer.proj, PATCHED_MODULE_ATTR)
 
 
 def test_patch_transformer_auto_uses_manifest_before_matching_adapter(tmp_path, monkeypatch):
@@ -224,6 +226,7 @@ def test_manifest_adapter_applies_split_linear_output_before_replacement(tmp_pat
     )
 
     assert isinstance(transformer.proj, SVDQW4A4Linear)
+    assert getattr(transformer.proj, PATCHED_MODULE_ATTR)
     patch_transformer(
         TinyManifestModel(out_features=128),
         checkpoint,
@@ -260,6 +263,7 @@ def test_manifest_adapter_replaces_awq_target(tmp_path):
     )
 
     assert isinstance(transformer.proj, AWQW4A16Linear)
+    assert getattr(transformer.proj, PATCHED_MODULE_ATTR)
 
 
 @pytest.mark.parametrize("splits", [3, 6])
@@ -294,7 +298,9 @@ def test_manifest_adapter_wraps_adanorm_awq_target(splits):
 
     assert isinstance(transformer.norm, ManifestAdaNormAWQW4A16)
     assert transformer.norm.splits == splits
+    assert getattr(transformer.norm, PATCHED_MODULE_ATTR)
     assert isinstance(transformer.norm.linear, AWQW4A16Linear)
+    assert getattr(transformer.norm.linear, PATCHED_MODULE_ATTR)
 
 
 def test_manifest_adanorm_wrapper_decodes_six_way_interleaved_output():

--- a/tests/test_manifest_adapter.py
+++ b/tests/test_manifest_adapter.py
@@ -6,7 +6,12 @@ from safetensors.torch import save_file
 from torch import nn
 
 from nunchaku_lite import patch_transformer
-from nunchaku_lite.adapters.manifest import ManifestAdapter, SplitLinearInput, SplitLinearOutput
+from nunchaku_lite.adapters.manifest import (
+    ManifestAdapter,
+    ManifestAdaNormAWQW4A16,
+    SplitLinearInput,
+    SplitLinearOutput,
+)
 from nunchaku_lite.linear import AWQW4A16Linear, SVDQW4A4Linear
 from nunchaku_lite.manifest import parse_runtime_manifest
 
@@ -18,6 +23,30 @@ class TinyManifestModel(nn.Module):
 
     def forward(self, x):
         return self.proj(x)
+
+
+class TinyAdaNormParent(nn.Module):
+    def __init__(self, *, in_features: int = 128, out_features: int = 768, with_emb: bool = False):
+        super().__init__()
+        self.emb = nn.Linear(in_features, in_features) if with_emb else None
+        self.silu = nn.Identity()
+        self.linear = nn.Linear(in_features, out_features)
+        self.norm = nn.Identity()
+
+
+class TinyAdaNormModel(nn.Module):
+    def __init__(self, *, splits: int = 6):
+        super().__init__()
+        self.norm = TinyAdaNormParent(out_features=128 * splits)
+
+
+class FixedLinear(nn.Module):
+    def __init__(self, output: torch.Tensor):
+        super().__init__()
+        self.output = output
+
+    def forward(self, x):
+        return self.output.to(device=x.device, dtype=x.dtype).expand(x.shape[0], -1)
 
 
 class MatchingFakeAdapter:
@@ -231,3 +260,108 @@ def test_manifest_adapter_replaces_awq_target(tmp_path):
     )
 
     assert isinstance(transformer.proj, AWQW4A16Linear)
+
+
+@pytest.mark.parametrize("splits", [3, 6])
+def test_manifest_adapter_wraps_adanorm_awq_target(splits):
+    manifest = _manifest(op="adanorm_awq_w4a16", precision="int4", group_size=64, rank=0)
+    manifest["targets"][0].update(
+        {
+            "name": "norm.linear",
+            "checkpoint_prefix": "norm.linear",
+            "source_modules": ["norm.linear"],
+            "op_options": {"adanorm_splits": splits},
+        }
+    )
+    transformer = TinyAdaNormModel(splits=splits)
+
+    ManifestAdapter().patch(
+        transformer,
+        {},
+        _quantization_config(manifest),
+        type(
+            "Options",
+            (),
+            {
+                "precision": "int4",
+                "torch_dtype": torch.bfloat16,
+                "device": None,
+                "strict": True,
+                "adapter_options": {},
+            },
+        )(),
+    )
+
+    assert isinstance(transformer.norm, ManifestAdaNormAWQW4A16)
+    assert transformer.norm.splits == splits
+    assert isinstance(transformer.norm.linear, AWQW4A16Linear)
+
+
+def test_manifest_adanorm_wrapper_decodes_six_way_interleaved_output():
+    parent = TinyAdaNormParent(in_features=4, out_features=24)
+    output = torch.arange(24, dtype=torch.float32)
+    wrapper = ManifestAdaNormAWQW4A16(parent, FixedLinear(output), splits=6)
+    x = torch.ones(1, 2, 4)
+
+    norm_x, gate_msa, shift_mlp, scale_mlp, gate_mlp = wrapper(x, emb=torch.zeros(1, 4))
+    decoded = output.view(1, -1, 6).permute(2, 0, 1)
+
+    assert torch.equal(norm_x, x * decoded[1][:, None] + decoded[0][:, None])
+    assert torch.equal(gate_msa, decoded[2])
+    assert torch.equal(shift_mlp, decoded[3])
+    assert torch.equal(scale_mlp, decoded[4] - 1)
+    assert torch.equal(gate_mlp, decoded[5])
+
+
+def test_manifest_adanorm_wrapper_decodes_three_way_interleaved_output():
+    parent = TinyAdaNormParent(in_features=4, out_features=12)
+    output = torch.arange(12, dtype=torch.float32)
+    wrapper = ManifestAdaNormAWQW4A16(parent, FixedLinear(output), splits=3)
+    x = torch.ones(1, 2, 4)
+
+    norm_x, gate_msa = wrapper(x, emb=torch.zeros(1, 4))
+    decoded = output.view(1, -1, 3).permute(2, 0, 1)
+
+    assert torch.equal(norm_x, x * decoded[1][:, None] + decoded[0][:, None])
+    assert torch.equal(gate_msa, decoded[2])
+
+
+def test_parse_runtime_manifest_rejects_invalid_adanorm_splits():
+    manifest = _manifest(op="adanorm_awq_w4a16", precision="int4", group_size=64, rank=0)
+    manifest["targets"][0]["op_options"] = {"adanorm_splits": 4}
+
+    with pytest.raises(ValueError, match="adanorm_splits to be 3 or 6"):
+        parse_runtime_manifest(_quantization_config(manifest))
+
+
+def test_manifest_adapter_rejects_adanorm_target_without_linear_child():
+    manifest = _manifest(op="adanorm_awq_w4a16", precision="int4", group_size=64, rank=0)
+    manifest["targets"][0].update(
+        {
+            "name": "norm.proj",
+            "checkpoint_prefix": "norm.proj",
+            "source_modules": ["norm.proj"],
+            "op_options": {"adanorm_splits": 6},
+        }
+    )
+    transformer = nn.Module()
+    transformer.norm = nn.Module()
+    transformer.norm.proj = nn.Linear(128, 768)
+
+    with pytest.raises(ValueError, match="must reference a '.linear' child"):
+        ManifestAdapter().patch(
+            transformer,
+            {},
+            _quantization_config(manifest),
+            type(
+                "Options",
+                (),
+                {
+                    "precision": "int4",
+                    "torch_dtype": torch.bfloat16,
+                    "device": None,
+                    "strict": True,
+                    "adapter_options": {},
+                },
+            )(),
+        )

--- a/tests/test_manifest_adapter.py
+++ b/tests/test_manifest_adapter.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -14,6 +15,8 @@ from nunchaku_lite.adapters.manifest import (
 )
 from nunchaku_lite.adapters.common import PATCHED_MODULE_ATTR
 from nunchaku_lite.linear import AWQW4A16Linear, SVDQW4A4Linear
+from nunchaku_lite.lora.core.layout import unpack_lowrank_weight
+from nunchaku_lite.lora.manifest import COMFYUI_FORMAT, KOHYA_FORMAT, PEFT_FORMAT, detect_manifest_lora_format
 from nunchaku_lite.manifest import parse_runtime_manifest
 
 
@@ -24,6 +27,15 @@ class TinyManifestModel(nn.Module):
 
     def forward(self, x):
         return self.proj(x)
+
+
+class TinyFusedManifestModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.q = nn.Linear(128, 128)
+        self.k = nn.Linear(128, 128)
+        self.v = nn.Linear(128, 128)
+        self.qkv = nn.Linear(128, 384)
 
 
 class TinyAdaNormParent(nn.Module):
@@ -371,3 +383,148 @@ def test_manifest_adapter_rejects_adanorm_target_without_linear_child():
                 },
             )(),
         )
+
+
+def test_manifest_lora_format_detection_routes_external_formats():
+    assert (
+        detect_manifest_lora_format(
+            {
+                "transformer.proj.lora_A.weight": torch.ones(1, 128),
+                "transformer.proj.lora_B.weight": torch.ones(128, 1),
+            }
+        )
+        == PEFT_FORMAT
+    )
+    assert (
+        detect_manifest_lora_format(
+            {
+                "lora_transformer_proj.lora_down.weight": torch.ones(1, 128),
+                "lora_transformer_proj.lora_up.weight": torch.ones(128, 1),
+            }
+        )
+        == KOHYA_FORMAT
+    )
+    assert (
+        detect_manifest_lora_format(
+            {
+                "diffusion_model.proj.lora_A.weight": torch.ones(1, 128),
+                "diffusion_model.proj.lora_B.weight": torch.ones(128, 1),
+            }
+        )
+        == COMFYUI_FORMAT
+    )
+
+
+def test_manifest_adapter_binds_generic_lora_runtime(tmp_path):
+    manifest = _manifest()
+    checkpoint = _write_manifest_checkpoint(tmp_path, TinyManifestModel(), manifest)
+
+    transformer = TinyManifestModel()
+    patch_transformer(transformer, checkpoint, target="manifest", torch_dtype=torch.bfloat16, device="cpu")
+
+    assert transformer._nunchaku_lite_target == "manifest"
+    assert callable(transformer.load_lora)
+    assert callable(transformer.set_adapters)
+    assert transformer._nunchaku_lite_loras == {}
+
+    lora = {
+        "transformer.proj.lora_A.weight": torch.ones(2, 128, dtype=torch.bfloat16),
+        "transformer.proj.lora_B.weight": torch.ones(128, 2, dtype=torch.bfloat16),
+    }
+    transformer.load_lora(lora, name="style")
+
+    assert transformer.get_list_adapters() == ["style"]
+    assert transformer.get_active_adapters() == ["style"]
+
+
+def test_manifest_generic_lora_accepts_kohya_suffix_alias(tmp_path):
+    manifest = _manifest()
+    checkpoint = _write_manifest_checkpoint(tmp_path, TinyManifestModel(), manifest)
+    transformer = patch_transformer(
+        TinyManifestModel(),
+        checkpoint,
+        target="manifest",
+        torch_dtype=torch.bfloat16,
+        device="cpu",
+    )
+
+    converted = transformer._convert_lora_to_nunchaku(
+        {
+            "lora_transformer_proj.lora_down.weight": torch.ones(2, 128, dtype=torch.bfloat16),
+            "lora_transformer_proj.lora_up.weight": torch.ones(128, 2, dtype=torch.bfloat16),
+        }
+    )
+
+    assert set(converted) == {"proj.proj_down", "proj.proj_up"}
+
+
+def test_manifest_generic_lora_accepts_comfyui_component_prefix(tmp_path):
+    manifest = _manifest()
+    checkpoint = _write_manifest_checkpoint(tmp_path, TinyManifestModel(), manifest)
+    transformer = patch_transformer(
+        TinyManifestModel(),
+        checkpoint,
+        target="manifest",
+        torch_dtype=torch.bfloat16,
+        device="cpu",
+    )
+
+    converted = transformer._convert_lora_to_nunchaku(
+        {
+            "diffusion_model.proj.lora_A.weight": torch.ones(2, 128, dtype=torch.bfloat16),
+            "diffusion_model.proj.lora_B.weight": torch.ones(128, 2, dtype=torch.bfloat16),
+        }
+    )
+
+    assert set(converted) == {"proj.proj_down", "proj.proj_up"}
+
+
+def test_manifest_generic_lora_fuses_source_module_branches(tmp_path):
+    manifest = _manifest()
+    manifest["targets"][0].update(
+        {
+            "name": "qkv",
+            "checkpoint_prefix": "qkv",
+            "source_modules": ["q", "k", "v"],
+            "has_bias": True,
+        }
+    )
+    checkpoint = _write_manifest_checkpoint(tmp_path, TinyFusedManifestModel(), manifest)
+    transformer = patch_transformer(
+        TinyFusedManifestModel(),
+        checkpoint,
+        target="manifest",
+        torch_dtype=torch.bfloat16,
+        device="cpu",
+    )
+
+    lora = {}
+    for value, branch in enumerate(("q", "k", "v"), start=1):
+        lora[f"transformer.{branch}.lora_A.weight"] = torch.ones(2, 128, dtype=torch.bfloat16)
+        lora[f"transformer.{branch}.lora_B.weight"] = torch.full((128, 2), value, dtype=torch.bfloat16)
+
+    converted = transformer._convert_lora_to_nunchaku(lora)
+    logical_up = unpack_lowrank_weight(converted["qkv.proj_up"], down=False)[:384, :2]
+
+    assert set(converted) == {"qkv.proj_down", "qkv.proj_up"}
+    assert torch.equal(logical_up[:128], torch.ones_like(logical_up[:128]))
+    assert torch.equal(logical_up[128:256], torch.full_like(logical_up[128:256], 2))
+    assert torch.equal(logical_up[256:384], torch.full_like(logical_up[256:384], 3))
+
+
+def test_manifest_pipeline_lora_methods_bind_when_component_runtime_is_bound(tmp_path):
+    manifest = _manifest()
+    checkpoint = _write_manifest_checkpoint(tmp_path, TinyManifestModel(), manifest)
+    transformer = patch_transformer(
+        TinyManifestModel(),
+        checkpoint,
+        target="manifest",
+        torch_dtype=torch.bfloat16,
+        device="cpu",
+    )
+    pipeline = SimpleNamespace(transformer=transformer)
+
+    ManifestAdapter().patch_pipeline(pipeline, component_name="transformer", component=transformer)
+
+    assert callable(pipeline.load_lora_weights)
+    assert pipeline._nunchaku_lite_lora_component_name == "transformer"

--- a/tests/test_sdxl_adapter.py
+++ b/tests/test_sdxl_adapter.py
@@ -48,6 +48,19 @@ def test_convert_sdxl_state_dict_maps_original_nunchaku_keys():
     assert "conv_in.weight" in converted
 
 
+def test_convert_sdxl_state_dict_leaves_corrected_keys_unchanged():
+    state = {
+        "down_blocks.0.attentions.0.transformer_blocks.0.attn1.to_qkv.proj_down": torch.empty(1),
+        "mid_block.attentions.0.transformer_blocks.0.attn2.to_q.smooth_factor_orig": torch.empty(1),
+        "conv_in.weight": torch.empty(1),
+    }
+
+    converted = convert_sdxl_state_dict(state)
+
+    assert converted is state
+    assert set(converted) == set(state)
+
+
 def test_patch_transformer_patches_sdxl_from_synthetic_checkpoint(tmp_path):
     rank = 4
     source = make_tiny_sdxl_unet()


### PR DESCRIPTION
Straightforward from checkpoint to building runtime patching, gain 25% VRAM reduction and 30% inference speed. For more latency gain, customs operations must be added such as grouped qkv with fused norm rotary, fuse linear gelu but that is where adapter comes to play as it changes model architecture